### PR TITLE
add "build" support for windows through wsl

### DIFF
--- a/Crystal.sublime-build
+++ b/Crystal.sublime-build
@@ -1,5 +1,9 @@
 {
-	"shell_cmd": "crystal \"$file\"",
+	"cmd": ["crystal", "\"$file\""],
+	"shell": true,
 	"file_regex": "^(...*?):([0-9]*):?([0-9]*)",
-	"selector": "source.crystal"
+	"selector": "source.crystal",
+	"windows": {
+		"cmd": ["bash", "-c", "crystal \"$file_name\""]
+	}
 }


### PR DESCRIPTION
The latest major windows update adds [wsl interoperability](https://blogs.msdn.microsoft.com/wsl/2016/10/19/windows-and-ubuntu-interoperability/) outside of the insider program. This should be utilized to *support* using the "build" command on windows.