### PR TITLE
Workaround for #23

### DIFF
--- a/Crystal.tmLanguage
+++ b/Crystal.tmLanguage
@@ -501,7 +501,7 @@
 			<key>contentName</key>
 			<string>variable.parameter.function.crystal</string>
 			<key>end</key>
-			<string>\)</string>
+			<string>\)\s*$|\)\s*:</string>
 			<key>endCaptures</key>
 			<dict>
 				<key>0</key>

--- a/Crystal.tmLanguage
+++ b/Crystal.tmLanguage
@@ -501,7 +501,7 @@
 			<key>contentName</key>
 			<string>variable.parameter.function.crystal</string>
 			<key>end</key>
-			<string>\)\s*$|\)\s*:</string>
+			<string>\)\s*$|\)\s*:|\)\s*;</string>
 			<key>endCaptures</key>
 			<dict>
 				<key>0</key>


### PR DESCRIPTION
Before:

![screenshot_20170729_073853](https://user-images.githubusercontent.com/3067335/28744946-6285d382-7432-11e7-9041-7f0ec8b7d6a3.png)


After:

![screenshot_20170729_065719](https://user-images.githubusercontent.com/3067335/28744934-05cb36fa-7432-11e7-8005-4f2bd7d9d2a0.png)

Fix #23, but still some work is needed because symbols are highlighted as parameters `:` `(` `)` `,`