### PR TITLE
Properly capture `[]?` as a method name.

### DIFF
--- a/Crystal.tmLanguage
+++ b/Crystal.tmLanguage
@@ -475,7 +475,7 @@
 			         (?&lt;=^|\s)(def)\s+                                              # the def keyword
 			         ( (?&gt;[a-zA-Z_\x{80}-\x{10FFFF}][\x{80}-\x{10FFFF}\w]*(?&gt;\.|::))?                                   # a method name prefix
 			           (?&gt;[a-zA-Z_\x{80}-\x{10FFFF}][\x{80}-\x{10FFFF}\w]*(?&gt;[?!]|=(?!&gt;))?                              # the method name
-			           |===?|&gt;[&gt;=]?|&lt;=&gt;|&lt;[&lt;=]?|[%&amp;`/\|]|\*\*?|=?~|[-+]@?|\[\]=?) )  # …or an operator method
+			           |===?|&gt;[&gt;=]?|&lt;=&gt;|&lt;[&lt;=]?|[%&amp;`/\|]|\*\*?|=?~|[-+]@?|\[\](?:=|\?)?) )  # …or an operator method
 			         \s*(\()                                                        # the openning parenthesis for arguments
 			        </string>
 			<key>beginCaptures</key>
@@ -527,7 +527,7 @@
 			         (?&lt;=^|\s)(def)\s+                                              # the def keyword
 			         ( (?&gt;[a-zA-Z_\x{80}-\x{10FFFF}][\w\x{80}-\x{10FFFF}]*(?&gt;\.|::))?                                   # a method name prefix
 			           (?&gt;[a-zA-Z_\x{80}-\x{10FFFF}][\w\x{80}-\x{10FFFF}]*(?&gt;[?!]|=(?!&gt;))?                              # the method name
-			           |===?|&gt;[&gt;=]?|&lt;=&gt;|&lt;[&lt;=]?|[%&amp;`/\|]|\*\*?|=?~|[-+]@?|\[\]=?) )  # …or an operator method
+			           |===?|&gt;[&gt;=]?|&lt;=&gt;|&lt;[&lt;=]?|[%&amp;`/\|]|\*\*?|=?~|[-+]@?|\[\](?:=|\?)?) )  # …or an operator method
 			         [ \t]                                                          # the space separating the arguments
 			         (?=[ \t]*[^\s#;])                                              # make sure arguments and not a comment follow
 			        </string>
@@ -583,7 +583,7 @@
 			         ( \s+                                                               # an optional group of whitespace followed by…
 			           ( (?&gt;[a-zA-Z_\x{80}-\x{10FFFF}][\w\x{80}-\x{10FFFF}]*(?&gt;\.|::))?                                      # a method name prefix
 			             (?&gt;[a-zA-Z_\x{80}-\x{10FFFF}][\w\x{80}-\x{10FFFF}]*(?&gt;[?!]|=(?!&gt;))?                                 # the method name
-			             |===?|&gt;[&gt;=]?|&lt;=&gt;|&lt;[&lt;=]?|[%&amp;`/\|]|\*\*?|=?~|[-+]@?|\[\]=?) ) )?  # …or an operator method
+			             |===?|&gt;[&gt;=]?|&lt;=&gt;|&lt;[&lt;=]?|[%&amp;`/\|]|\*\*?|=?~|[-+]@?|\[\](?:=|\?)?) ) )?  # …or an operator method
 			        </string>
 			<key>name</key>
 			<string>meta.function.method.without-arguments.crystal</string>
@@ -1613,7 +1613,7 @@
 			<key>comment</key>
 			<string>symbols</string>
 			<key>match</key>
-			<string>(?&lt;!:)(:)(?&gt;[a-zA-Z_\x{80}-\x{10FFFF}][\w\x{80}-\x{10FFFF}]*(?&gt;[?!]|=(?![&gt;=]))?|===?|&gt;[&gt;=]?|&lt;[&lt;=]?|&lt;=&gt;|[%&amp;`/\|]|\*\*?|=?~|[-+]@?|\[\]=?|@@?[a-zA-Z_\x{80}-\x{10FFFF}][\w\x{80}-\x{10FFFF}]*)</string>
+			<string>(?&lt;!:)(:)(?&gt;[a-zA-Z_\x{80}-\x{10FFFF}][\w\x{80}-\x{10FFFF}]*(?&gt;[?!]|=(?![&gt;=]))?|===?|&gt;[&gt;=]?|&lt;[&lt;=]?|&lt;=&gt;|[%&amp;`/\|]|\*\*?|=?~|[-+]@?|\[\](?:=|\?)?|@@?[a-zA-Z_\x{80}-\x{10FFFF}][\w\x{80}-\x{10FFFF}]*)</string>
 			<key>name</key>
 			<string>constant.other.symbol.crystal</string>
 		</dict>


### PR DESCRIPTION
Previously, the `?` was not included as part of the method name, meaning it would not appear as one entity when highlighted. These changes modify the already-optional `=` for `[]=` to also allow `?`.

<img width="144" alt="screen shot 2017-10-30 at 11 21 44 pm" src="https://user-images.githubusercontent.com/783733/32206173-efa96d60-bdc9-11e7-8f56-8f8b9d180f16.png">

Fixes #29.