### PR TITLE
Update file extension references in snippets

### DIFF
--- a/snippets/Dir[-__-].sublime-snippet
+++ b/snippets/Dir[-__-].sublime-snippet
@@ -1,5 +1,5 @@
 <snippet>
-    <content><![CDATA[Dir[${1:"${2:glob/**/*.rb}"}]]]></content>
+    <content><![CDATA[Dir[${1:"${2:glob/**/*.cr}"}]]]></content>
     <tabTrigger>Dir</tabTrigger>
     <scope>source.crystal</scope>
     <description>Dir[".."]</description>

--- a/snippets/class-..-DelegateClass-..-initialize-..-end-(class).sublime-snippet
+++ b/snippets/class-..-DelegateClass-..-initialize-..-end-(class).sublime-snippet
@@ -1,5 +1,5 @@
 <snippet>
-    <content><![CDATA[class ${1:${TM_FILENAME/(?:\A|_)([A-Za-z0-9]+)(?:\.rb)?/(?2::\u$1)/g}} < DelegateClass(${2:ParentClass})
+    <content><![CDATA[class ${1:${TM_FILENAME/(?:\A|_)([A-Za-z0-9]+)(?:\.cr)?/(?2::\u$1)/g}} < DelegateClass(${2:ParentClass})
 	def initialize${3/(^.*?\S.*)|.*/(?1:\()/}${3:args}${3/(^.*?\S.*)|.*/(?1:\))/}
 		super(${4:del_obj})
 

--- a/snippets/class-..-ParentClass-..-initialize-..-end.sublime-snippet
+++ b/snippets/class-..-ParentClass-..-initialize-..-end.sublime-snippet
@@ -1,5 +1,5 @@
 <snippet>
-    <content><![CDATA[class ${1:${TM_FILENAME/(?:\A|_)([A-Za-z0-9]+)(?:\.rb)?/(?2::\u$1)/g}} < ${2:ParentClass}
+    <content><![CDATA[class ${1:${TM_FILENAME/(?:\A|_)([A-Za-z0-9]+)(?:\.cr)?/(?2::\u$1)/g}} < ${2:ParentClass}
 	def initialize${3/(^.*?\S.*)|.*/(?1:\()/}${3:args}${3/(^.*?\S.*)|.*/(?1:\))/}
 		$0
 	end

--- a/snippets/class-..-Struct-..-initialize-..-end.sublime-snippet
+++ b/snippets/class-..-Struct-..-initialize-..-end.sublime-snippet
@@ -1,5 +1,5 @@
 <snippet>
-    <content><![CDATA[${1:${TM_FILENAME/(?:\A|_)([A-Za-z0-9]+)(?:\.rb)?/(?2::\u$1)/g}} = Struct.new(:${2:attr_names}) do
+    <content><![CDATA[${1:${TM_FILENAME/(?:\A|_)([A-Za-z0-9]+)(?:\.cr)?/(?2::\u$1)/g}} = Struct.new(:${2:attr_names}) do
 	def ${3:method_name}
 		$0
 	end

--- a/snippets/class-..-end-(cla).sublime-snippet
+++ b/snippets/class-..-end-(cla).sublime-snippet
@@ -1,5 +1,5 @@
 <snippet>
-    <content><![CDATA[class ${1:${TM_FILENAME/(?:\A|_)([A-Za-z0-9]+)(?:\.rb)?/(?2::\u$1)/g}}
+    <content><![CDATA[class ${1:${TM_FILENAME/(?:\A|_)([A-Za-z0-9]+)(?:\.cr)?/(?2::\u$1)/g}}
 	$0
 end]]></content>
     <tabTrigger>cla</tabTrigger>

--- a/snippets/class-..-initialize-..-end.sublime-snippet
+++ b/snippets/class-..-initialize-..-end.sublime-snippet
@@ -1,5 +1,5 @@
 <snippet>
-    <content><![CDATA[class ${1:${TM_FILENAME/(?:\A|_)([A-Za-z0-9]+)(?:\.rb)?/(?2::\u$1)/g}}
+    <content><![CDATA[class ${1:${TM_FILENAME/(?:\A|_)([A-Za-z0-9]+)(?:\.cr)?/(?2::\u$1)/g}}
 	def initialize${2/(^.*?\S.*)|.*/(?1:\()/}${2:args}${2/(^.*?\S.*)|.*/(?1:\))/}
 		$0
 	end

--- a/snippets/module-..-ClassMethods-..-end.sublime-snippet
+++ b/snippets/module-..-ClassMethods-..-end.sublime-snippet
@@ -1,5 +1,5 @@
 <snippet>
-    <content><![CDATA[module ${1:${TM_FILENAME/(?:\A|_)([A-Za-z0-9]+)(?:\.rb)?/(?2::\u$1)/g}}
+    <content><![CDATA[module ${1:${TM_FILENAME/(?:\A|_)([A-Za-z0-9]+)(?:\.cr)?/(?2::\u$1)/g}}
 	module ClassMethods
 		$0
 	end

--- a/snippets/module-..-end.sublime-snippet
+++ b/snippets/module-..-end.sublime-snippet
@@ -1,5 +1,5 @@
 <snippet>
-    <content><![CDATA[module ${1:${TM_FILENAME/(?:\A|_)([A-Za-z0-9]+)(?:\.rb)?/(?2::\u$1)/g}}
+    <content><![CDATA[module ${1:${TM_FILENAME/(?:\A|_)([A-Za-z0-9]+)(?:\.cr)?/(?2::\u$1)/g}}
 	$0
 end]]></content>
     <tabTrigger>mod</tabTrigger>

--- a/snippets/module-..-module_function-..-end.sublime-snippet
+++ b/snippets/module-..-module_function-..-end.sublime-snippet
@@ -1,5 +1,5 @@
 <snippet>
-    <content><![CDATA[module ${1:${TM_FILENAME/(?:\A|_)([A-Za-z0-9]+)(?:\.rb)?/(?2::\u$1)/g}}
+    <content><![CDATA[module ${1:${TM_FILENAME/(?:\A|_)([A-Za-z0-9]+)(?:\.cr)?/(?2::\u$1)/g}}
 	module_function
 
 	$0


### PR DESCRIPTION
Expanding filename dependent snippets such as `cla` does not result in
the right behavior. Given a filename `user.cr`, expanding the snippet
`cla` will yield the following:

    class Test.cr
    end

This commit addresses the issue by changing references to `.rb` with
`.cr` instead.