### PR TITLE
Removes the --format option as it was removed in 0.27.1

### DIFF
--- a/crystal_format.py
+++ b/crystal_format.py
@@ -29,7 +29,7 @@ class CrystalFormatCommand(sublime_plugin.TextCommand):
     window = self.view.window()
 
     settings = sublime.load_settings('Crystal.sublime-settings')
-    command = [settings.get("crystal_cmd"), "tool", "format", "-", "--format", "json"]
+    command = [settings.get("crystal_cmd"), "tool", "format", "-"]
 
     popen_args = dict(args=command, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     # Prevent flashing terminal windows


### PR DESCRIPTION
Noob with python/sublime plugins, but this seems to work.