### PR TITLE
Fix #67

### DIFF
--- a/Crystal.tmLanguage
+++ b/Crystal.tmLanguage
@@ -1953,6 +1953,10 @@
 				</dict>
 				<dict>
 					<key>include</key>
+					<string>text.html.basic</string>
+				</dict>
+				<dict>
+					<key>include</key>
 					<string>source.js</string>
 				</dict>
 				<dict>


### PR DESCRIPTION
It stops HTML tags within `JAVASCRIPT` or `JS` heredoc identifiers from breaking syntax highlighting beyond them. Javascript syntax is now highlighted both outside and within `<script>` tags inside the heredoc identifiers.

In other words, this:

```crystal
<<-JAVASCRIPT
  <script>
    function a (abc) {
      abc = 5
    }
  </script>
JAVASCRIPT
```

and this:

```crystal
<<-JAVASCRIPT
  function a (abc) {
    abc = 5
  }
JAVASCRIPT
```

Are correctly highlighted.

(Note: not extensively tested)