### PR TITLE
Fix #41

### DIFF
--- a/Crystal.tmLanguage
+++ b/Crystal.tmLanguage
@@ -282,7 +282,7 @@
 			<key>comment</key>
 			<string>everything being a reserved word, not a value and needing a 'end' is a..</string>
 			<key>match</key>
-			<string>(?&lt;!\.)\b(BEGIN|alias|as|begin|case|select|abstract|class|END|ensure|for|fun|if|ifdef|in|lib|module|of|out|private|protected|rescue|struct|with|union|enum|macro|then|type|unless|until|while)\b(?![?!])</string>
+			<string>(?&lt;!\.)\b(BEGIN|alias|as|begin|case|select|abstract|class|END|ensure|for|fun|if|ifdef|in|lib|module|of|out|private|protected|rescue|struct|with|union|enum|macro|then|unless|until|while)\b(?![?!])|(?&lt;!\.)\btype\b\s*(?=[A-Z])</string>
 			<key>name</key>
 			<string>keyword.control.primary.crystal</string>
 		</dict>


### PR DESCRIPTION
It now only highlights `type` as a reserved word if it's followed by (anything starting with) a capital letter, like `type Abc`.