### PR TITLE
Improve indentation rules

### DIFF
--- a/preferences/Miscellaneous.tmPreferences
+++ b/preferences/Miscellaneous.tmPreferences
@@ -13,7 +13,7 @@
 		<key>increaseIndentPattern</key>
 		<string>(?x)^
     (\s*
-        (module|class|struct|union|lib|(private\s+|protected\s+)?(def|macro)
+        ((private\s+)?module|((abstract|private)\s+)?class|struct|union|lib|((abstract|private|protected)\s+)?def|(private\s+)?macro
         |unless|if|else|elsif
         |case|when
         |begin|rescue|ensure


### PR DESCRIPTION
- Add indentation for `private module`
- Add indentation for `abstract class` and `private class`
- Add indentation for `abstract def`
- Add indentation for `private macro`
- Remove indentation for `protected macro` (not valid)